### PR TITLE
Add CI for PR's

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
     - master
-
 jobs:
   build:
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - master
+
 jobs:
   build:
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,47 @@
+name: ci pr
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      ARM_CLIENT_ID: 28f77aaa-53e7-47bc-ad78-d8d7b2b98009
+      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: b087ec80-bbdd-4b0a-9fb3-ca2eb729208c
+      ARM_TENANT_ID: 72f988bf-86f1-41af-91ab-2d7cd011db47
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Terraform format
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: 0.12.13
+        tf_actions_subcommand: fmt
+        tf_actions_working_dir: '.'
+        tf_actions_comment: true
+    - name: terraform init
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: 0.12.13
+        tf_actions_subcommand: init
+        tf_actions_working_dir: '.'
+        tf_actions_comment: true
+    - name: terraform validate
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: 0.12.13
+        tf_actions_subcommand: validate
+        tf_actions_working_dir: '.'
+        tf_actions_comment: true
+    - name: terraform plan
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: 0.12.13
+        tf_actions_subcommand: plan
+        tf_actions_working_dir: '.'
+        tf_actions_comment: true


### PR DESCRIPTION
Same as master ci but triggers on pr creation/update.
Terraform actions commenting is also enabled (disabled for ci-master.yml)