### PR TITLE
Add GITHUB_TOKEN env var so actions can post

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -24,6 +24,8 @@ jobs:
         tf_actions_subcommand: fmt
         tf_actions_working_dir: '.'
         tf_actions_comment: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}        
     - name: terraform init
       uses: hashicorp/terraform-github-actions@master
       with:
@@ -31,6 +33,8 @@ jobs:
         tf_actions_subcommand: init
         tf_actions_working_dir: '.'
         tf_actions_comment: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}        
     - name: terraform validate
       uses: hashicorp/terraform-github-actions@master
       with:
@@ -38,6 +42,8 @@ jobs:
         tf_actions_subcommand: validate
         tf_actions_working_dir: '.'
         tf_actions_comment: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}        
     - name: terraform plan
       uses: hashicorp/terraform-github-actions@master
       with:
@@ -45,3 +51,5 @@ jobs:
         tf_actions_subcommand: plan
         tf_actions_working_dir: '.'
         tf_actions_comment: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}        


### PR DESCRIPTION
Terraform github actions needs the GITHUB_TOKEN environment set so that it can authorize to Github to post comments